### PR TITLE
Fix README for calendar-app subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repository contains a simple Laravel + Vue application for creating events 
 ## Setup
 
 ```bash
+# Enter the Laravel application directory
+cd calendar-app
+
 # Install PHP dependencies
 composer install
 
@@ -21,4 +24,6 @@ php artisan migrate
 php artisan serve
 ```
 
-The application uses SQLite by default and stores the database at `database/database.sqlite`.
+All Laravel commands should be executed from inside the `calendar-app` directory.
+
+The application uses SQLite by default and stores the database at `calendar-app/database/database.sqlite`.


### PR DESCRIPTION
## Summary
- clarify that all Composer, NPM and artisan commands should be run inside `calendar-app`
- update database path in README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e3eaaec4832ea6d2ff10fb9ed275