### PR TITLE
Add RSVP status validation

### DIFF
--- a/calendar-app/app/Http/Controllers/RsvpController.php
+++ b/calendar-app/app/Http/Controllers/RsvpController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Event;
 use App\Models\Rsvp;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class RsvpController extends Controller
 {
@@ -13,7 +14,7 @@ class RsvpController extends Controller
         $data = $request->validate([
             'name' => 'required|string',
             'email' => 'required|email',
-            'status' => 'required|string',
+            'status' => ['required', Rule::in(['yes', 'no', 'maybe'])],
         ]);
         $data['event_id'] = $event->id;
 

--- a/calendar-app/tests/Feature/RsvpValidationTest.php
+++ b/calendar-app/tests/Feature/RsvpValidationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RsvpValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_status_must_be_valid(): void
+    {
+        $event = Event::create([
+            'title' => 'Test Event',
+            'description' => 'desc',
+            'start_time' => now(),
+            'end_time' => now()->addHour(),
+        ]);
+
+        $response = $this->postJson("/api/events/{$event->id}/rsvp", [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'status' => 'invalid',
+        ]);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary
- validate `status` with `Rule::in(['yes', 'no', 'maybe'])`
- cover invalid status values in new feature test

## Testing
- `php artisan test` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846e3ee3770832e93016bb4401d1a1c