### PR TITLE
Return 201 responses for new resources

### DIFF
--- a/calendar-app/app/Http/Controllers/EventController.php
+++ b/calendar-app/app/Http/Controllers/EventController.php
@@ -21,7 +21,9 @@ class EventController extends Controller
             'end_time' => 'required|date|after:start_time',
         ]);
 
-        return Event::create($data);
+        $event = Event::create($data);
+
+        return response()->json($event, 201);
     }
 
     public function show(Event $event)

--- a/calendar-app/app/Http/Controllers/RsvpController.php
+++ b/calendar-app/app/Http/Controllers/RsvpController.php
@@ -17,6 +17,8 @@ class RsvpController extends Controller
         ]);
         $data['event_id'] = $event->id;
 
-        return Rsvp::create($data);
+        $rsvp = Rsvp::create($data);
+
+        return response()->json($rsvp, 201);
     }
 }

--- a/calendar-app/tests/Feature/EventRsvpTest.php
+++ b/calendar-app/tests/Feature/EventRsvpTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventRsvpTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function event_store_returns_created_status(): void
+    {
+        $payload = [
+            'title' => 'Test Event',
+            'description' => 'Example',
+            'start_time' => '2024-01-01 10:00:00',
+            'end_time' => '2024-01-01 11:00:00',
+        ];
+
+        $response = $this->postJson('/api/events', $payload);
+
+        $response->assertStatus(201)
+                 ->assertJsonFragment(['title' => 'Test Event']);
+    }
+
+    /** @test */
+    public function rsvp_store_returns_created_status(): void
+    {
+        $event = Event::create([
+            'title' => 'Another Event',
+            'start_time' => '2024-01-02 10:00:00',
+            'end_time' => '2024-01-02 11:00:00',
+        ]);
+
+        $payload = [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'status' => 'confirmed',
+        ];
+
+        $response = $this->postJson("/api/events/{$event->id}/rsvp", $payload);
+
+        $response->assertStatus(201)
+                 ->assertJsonFragment(['email' => 'john@example.com']);
+    }
+}

--- a/calendar-app/tests/Feature/ExampleTest.php
+++ b/calendar-app/tests/Feature/ExampleTest.php
@@ -2,17 +2,18 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
     /**
      * A basic test example.
      */
     public function test_the_application_returns_a_successful_response(): void
     {
-        $response = $this->get('/');
+        $response = $this->get('/api/events');
 
         $response->assertStatus(200);
     }


### PR DESCRIPTION
## Summary
- return json responses with 201 status when creating events and RSVPs
- add feature tests covering event and RSVP creation
- make example feature test use `/api/events` and refresh database

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6846e3ff06e0832ebdf0c475d8fde289