### PR TITLE
Add datetime casts for event times

### DIFF
--- a/calendar-app/app/Models/Event.php
+++ b/calendar-app/app/Models/Event.php
@@ -9,6 +9,11 @@ class Event extends Model
 {
     protected $fillable = ['title', 'description', 'start_time', 'end_time'];
 
+    protected $casts = [
+        'start_time' => 'datetime',
+        'end_time' => 'datetime',
+    ];
+
     public function rsvps(): HasMany
     {
         return $this->hasMany(Rsvp::class);

--- a/calendar-app/tests/Feature/ExampleTest.php
+++ b/calendar-app/tests/Feature/ExampleTest.php
@@ -2,17 +2,18 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
     /**
      * A basic test example.
      */
     public function test_the_application_returns_a_successful_response(): void
     {
-        $response = $this->get('/');
+        $response = $this->get('/api/events');
 
         $response->assertStatus(200);
     }

--- a/calendar-app/tests/Unit/EventTest.php
+++ b/calendar-app/tests/Unit/EventTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Event;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_casts_start_and_end_times_to_carbon_instances(): void
+    {
+        $event = Event::create([
+            'title' => 'Sample',
+            'description' => 'Test',
+            'start_time' => '2024-01-01 10:00:00',
+            'end_time' => '2024-01-01 12:00:00',
+        ]);
+
+        $this->assertInstanceOf(Carbon::class, $event->start_time);
+        $this->assertInstanceOf(Carbon::class, $event->end_time);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `Event` model casts `start_time` and `end_time` to Carbon instances
- adjust sample feature test to hit API rather than the Vite powered page
- add new unit test verifying the datetime casts

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6846e3f84a00832ea64c53bf4388345b