### PR TITLE
Extend Laravel controller base

### DIFF
--- a/calendar-app/app/Http/Controllers/Controller.php
+++ b/calendar-app/app/Http/Controllers/Controller.php
@@ -2,7 +2,12 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 }

--- a/calendar-app/app/Http/Controllers/EventController.php
+++ b/calendar-app/app/Http/Controllers/EventController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Event;
 use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
 
 class EventController extends Controller
 {

--- a/calendar-app/app/Http/Controllers/RsvpController.php
+++ b/calendar-app/app/Http/Controllers/RsvpController.php
@@ -6,6 +6,7 @@ use App\Models\Event;
 use App\Models\Rsvp;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
+use App\Http\Controllers\Controller;
 
 class RsvpController extends Controller
 {


### PR DESCRIPTION
## Summary
- extend the app base Controller from `Illuminate\Routing\Controller`
- add standard Laravel traits to the base Controller
- explicitly import the base Controller in existing controllers

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847efde45c8832ea7d874fee2a0b7d4