### PR TITLE
Add CreatesApplication trait

### DIFF
--- a/calendar-app/tests/CreatesApplication.php
+++ b/calendar-app/tests/CreatesApplication.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    /**
+     * Creates the application.
+     */
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/calendar-app/tests/TestCase.php
+++ b/calendar-app/tests/TestCase.php
@@ -3,8 +3,9 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Tests\CreatesApplication;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- implement a CreatesApplication trait for Laravel tests
- use this trait in the base TestCase

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6847f07c12d8832eb2ca172d5de975f8