### PR TITLE
Add request classes for event and RSVP store

### DIFF
--- a/calendar-app/app/Http/Controllers/EventController.php
+++ b/calendar-app/app/Http/Controllers/EventController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Event;
 use Illuminate\Http\Request;
+use App\Http\Requests\StoreEventRequest;
 use App\Http\Controllers\Controller;
 
 class EventController extends Controller
@@ -13,14 +14,9 @@ class EventController extends Controller
         return Event::with('rsvps')->get();
     }
 
-    public function store(Request $request)
+    public function store(StoreEventRequest $request)
     {
-        $data = $request->validate([
-            'title' => 'required|string',
-            'description' => 'nullable|string',
-            'start_time' => 'required|date',
-            'end_time' => 'required|date|after:start_time',
-        ]);
+        $data = $request->validated();
 
         $event = Event::create($data);
 

--- a/calendar-app/app/Http/Controllers/RsvpController.php
+++ b/calendar-app/app/Http/Controllers/RsvpController.php
@@ -4,19 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\Event;
 use App\Models\Rsvp;
-use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
+use App\Http\Requests\StoreRsvpRequest;
 use App\Http\Controllers\Controller;
 
 class RsvpController extends Controller
 {
-    public function store(Request $request, Event $event)
+    public function store(StoreRsvpRequest $request, Event $event)
     {
-        $data = $request->validate([
-            'name' => 'required|string',
-            'email' => 'required|email',
-            'status' => ['required', Rule::in(['yes', 'no', 'maybe'])],
-        ]);
+        $data = $request->validated();
         $data['event_id'] = $event->id;
 
         $rsvp = Rsvp::create($data);

--- a/calendar-app/app/Http/Requests/StoreEventRequest.php
+++ b/calendar-app/app/Http/Requests/StoreEventRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreEventRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string',
+            'description' => 'nullable|string',
+            'start_time' => 'required|date',
+            'end_time' => 'required|date|after:start_time',
+        ];
+    }
+}

--- a/calendar-app/app/Http/Requests/StoreRsvpRequest.php
+++ b/calendar-app/app/Http/Requests/StoreRsvpRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreRsvpRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string',
+            'email' => 'required|email',
+            'status' => ['required', Rule::in(['yes', 'no', 'maybe'])],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add `StoreEventRequest` and `StoreRsvpRequest`
- refactor controllers to use the new requests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6847f2071254832ebe097d8ac3a634ae