### PR TITLE
Add factories and use them in tests

### DIFF
--- a/calendar-app/app/Models/Event.php
+++ b/calendar-app/app/Models/Event.php
@@ -2,11 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Event extends Model
 {
+    use HasFactory;
     protected $fillable = ['title', 'description', 'start_time', 'end_time'];
 
     protected $casts = [

--- a/calendar-app/app/Models/Rsvp.php
+++ b/calendar-app/app/Models/Rsvp.php
@@ -2,11 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Rsvp extends Model
 {
+    use HasFactory;
     protected $fillable = ['event_id', 'name', 'email', 'status'];
 
     public function event(): BelongsTo

--- a/calendar-app/database/factories/EventFactory.php
+++ b/calendar-app/database/factories/EventFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Event>
+ */
+class EventFactory extends Factory
+{
+    public function definition(): array
+    {
+        $start = $this->faker->dateTimeBetween('now', '+1 week');
+
+        return [
+            'title' => $this->faker->sentence(3),
+            'description' => $this->faker->sentence(),
+            'start_time' => $start,
+            'end_time' => (clone $start)->modify('+1 hour'),
+        ];
+    }
+}

--- a/calendar-app/database/factories/RsvpFactory.php
+++ b/calendar-app/database/factories/RsvpFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\Rsvp;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Rsvp>
+ */
+class RsvpFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'status' => $this->faker->randomElement(['yes', 'no', 'maybe']),
+        ];
+    }
+}

--- a/calendar-app/tests/Feature/EventRsvpTest.php
+++ b/calendar-app/tests/Feature/EventRsvpTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Event;
+use App\Models\Rsvp;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -29,17 +30,9 @@ class EventRsvpTest extends TestCase
     /** @test */
     public function rsvp_store_returns_created_status(): void
     {
-        $event = Event::create([
-            'title' => 'Another Event',
-            'start_time' => '2024-01-02 10:00:00',
-            'end_time' => '2024-01-02 11:00:00',
-        ]);
+        $event = Event::factory()->create();
 
-        $payload = [
-            'name' => 'John Doe',
-            'email' => 'john@example.com',
-            'status' => 'yes',
-        ];
+        $payload = Rsvp::factory()->make(['email' => 'john@example.com'])->only(['name', 'email', 'status']);
 
         $response = $this->postJson("/api/events/{$event->id}/rsvp", $payload);
 
@@ -50,17 +43,9 @@ class EventRsvpTest extends TestCase
     /** @test */
     public function can_retrieve_events_with_related_rsvps(): void
     {
-        $event = Event::create([
-            'title' => 'Party',
-            'start_time' => '2024-01-03 10:00:00',
-            'end_time' => '2024-01-03 11:00:00',
-        ]);
+        $event = Event::factory()->create();
 
-        $this->postJson("/api/events/{$event->id}/rsvp", [
-            'name' => 'Alice',
-            'email' => 'alice@example.com',
-            'status' => 'yes',
-        ]);
+        Rsvp::factory()->create(['event_id' => $event->id, 'email' => 'alice@example.com']);
 
         $response = $this->getJson('/api/events');
 

--- a/calendar-app/tests/Feature/RsvpValidationTest.php
+++ b/calendar-app/tests/Feature/RsvpValidationTest.php
@@ -12,12 +12,7 @@ class RsvpValidationTest extends TestCase
 
     public function test_status_must_be_valid(): void
     {
-        $event = Event::create([
-            'title' => 'Test Event',
-            'description' => 'desc',
-            'start_time' => now(),
-            'end_time' => now()->addHour(),
-        ]);
+        $event = Event::factory()->create();
 
         $response = $this->postJson("/api/events/{$event->id}/rsvp", [
             'name' => 'John Doe',

--- a/calendar-app/tests/Unit/EventTest.php
+++ b/calendar-app/tests/Unit/EventTest.php
@@ -13,12 +13,7 @@ class EventTest extends TestCase
 
     public function test_it_casts_start_and_end_times_to_carbon_instances(): void
     {
-        $event = Event::create([
-            'title' => 'Sample',
-            'description' => 'Test',
-            'start_time' => '2024-01-01 10:00:00',
-            'end_time' => '2024-01-01 12:00:00',
-        ]);
+        $event = Event::factory()->create();
 
         $this->assertInstanceOf(Carbon::class, $event->start_time);
         $this->assertInstanceOf(Carbon::class, $event->end_time);


### PR DESCRIPTION
## Summary
- add database factories for `Event` and `Rsvp`
- enable factories on `Event` and `Rsvp` models
- simplify tests by relying on factories

## Testing
- `php artisan test --testsuite Feature,Unit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6847f481177c832eaed2d4d105b3f2ab