### PR TITLE
Improve repository cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This repository contains a simple Laravel + Vue application for creating events and tracking RSVPs.
 
+## Cloning the repository
+
+Before running any Git commands, clone the project and ensure the remote is set. This avoids errors such as `fatal: not a git repository`.
+
+```bash
+# Clone from GitHub
+git clone https://github.com/<your-username>/solid-wtf.git
+cd solid-wtf
+
+# If the remote is missing, add it
+git remote add origin https://github.com/<your-username>/solid-wtf.git
+
+# Pull the latest changes
+git pull origin main
+```
+
 ## Requirements
 
  - PHP **8.2** or newer


### PR DESCRIPTION
## Summary
- document basic `git clone` and pulling steps in the README

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847f821b4f0832ea167a62a3a30db55