### PR TITLE
Remove pending default on rsvp status

### DIFF
--- a/calendar-app/database/migrations/2025_06_09_132953_create_rsvps_table.php
+++ b/calendar-app/database/migrations/2025_06_09_132953_create_rsvps_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->foreignId('event_id')->constrained()->onDelete('cascade');
             $table->string('name');
             $table->string('email');
-            $table->string('status')->default('pending');
+            $table->string('status');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Summary
- adjust rsvps migration to remove `default('pending')`
- run migrations and ensure tests pass

## Testing
- `php artisan migrate:fresh`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6847f7db891c832eadff8beba56d9035