### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,25 @@ git pull origin main
 ## Requirements
 
  - PHP **8.2** or newer
- - [Composer](https://getcomposer.org/)
- - Node.js **18+** (see `.nvmrc` for the exact version)
- - npm
+- [Composer](https://getcomposer.org/)
+- Node.js **18+** (see `.nvmrc` for the exact version)
+- npm
+
+## Quick Setup
+
+Run the included `setup.sh` script from the repository root to install Composer
+and NPM dependencies and prepare the application:
+
+```bash
+./setup.sh
+```
+
+After it completes you can start the server:
+
+```bash
+cd calendar-app
+php artisan serve
+```
 
 ## Setup
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Change to the Laravel application directory
+cd "$(dirname "$0")/calendar-app"
+
+# Copy environment file if it doesn't exist
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+# Ensure SQLite database file exists
+if [ ! -f database/database.sqlite ]; then
+  mkdir -p database
+  touch database/database.sqlite
+fi
+
+# Install PHP dependencies
+composer install
+
+# Install node dependencies
+npm install
+
+# Build frontend assets
+npm run build
+
+# Generate application key
+php artisan key:generate --ansi
+
+# Run database migrations
+php artisan migrate --force --ansi
+
+echo "Setup complete. You can now run 'php artisan serve' inside calendar-app.'"


### PR DESCRIPTION
## Summary
- add `setup.sh` for simple one-step install of Composer and NPM dependencies
- document quick setup section in `README`

## Testing
- `composer install`
- `npm install`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6847f9d3e32c832ebede4d6b4799358e