### PR TITLE
Add organizer details to ICS

### DIFF
--- a/calendar-app/app/Http/Controllers/EventIcsController.php
+++ b/calendar-app/app/Http/Controllers/EventIcsController.php
@@ -5,12 +5,15 @@ namespace App\Http\Controllers;
 use App\Models\Event;
 use Eluceo\iCal\Component\Calendar;
 use Eluceo\iCal\Component\Event as IcsEvent;
+use Eluceo\iCal\Property\Event\Organizer;
 
 class EventIcsController extends Controller
 {
     public function __invoke(Event $event)
     {
         $calendar = new Calendar(config('app.url'));
+        $calendar->setMethod(Calendar::METHOD_REQUEST);
+
         $vEvent = new IcsEvent();
         $vEvent->setDtStart($event->start_time)
             ->setDtEnd($event->end_time)
@@ -19,6 +22,16 @@ class EventIcsController extends Controller
         if ($event->description) {
             $vEvent->setDescription($event->description);
         }
+
+        $organizer = new Organizer(
+            'mailto:' . config('mail.from.address'),
+            ['CN' => config('mail.from.name')]
+        );
+        $vEvent->setOrganizer($organizer);
+        $vEvent->addAttendee(
+            'mailto:' . request('email', config('mail.from.address')),
+            ['CN' => request('name', config('mail.from.name'))]
+        );
 
         $calendar->addEvent($vEvent);
 

--- a/calendar-app/tests/Feature/IcsDownloadTest.php
+++ b/calendar-app/tests/Feature/IcsDownloadTest.php
@@ -14,11 +14,14 @@ class IcsDownloadTest extends TestCase
     {
         $event = Event::factory()->create(['title' => 'Conference']);
 
-        $response = $this->get("/api/events/{$event->id}/ics");
+        $response = $this->get("/api/events/{$event->id}/ics?email=john@example.com&name=John");
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'text/calendar; charset=utf-8');
         $response->assertSee('BEGIN:VCALENDAR');
         $response->assertSee('SUMMARY:Conference');
+        $response->assertSee('METHOD:REQUEST');
+        $response->assertSee('ORGANIZER');
+        $response->assertSee('ATTENDEE');
     }
 }


### PR DESCRIPTION
## Summary
- include METHOD:REQUEST with organizer and attendee in ICS
- assert new fields in ICS download test

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6848261c3808832e9e221b08fc60ec8e