### PR TITLE
Add event filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Events can be downloaded as `.ics` files via the API:
 curl http://localhost:8000/api/events/{id}/ics -o event.ics
 ```
 
+### Event Filtering
+
+The events endpoint accepts optional query parameters to filter results:
+
+```bash
+curl "http://localhost:8000/api/events?title=Meeting&start=2024-01-01&end=2024-01-31"
+```
+
 ## Setup
 
 ```bash

--- a/TASKS.md
+++ b/TASKS.md
@@ -19,7 +19,7 @@ This document tracks potential enhancements for the calendar application.
   - Enable drag-and-drop event interactions.
 
 - [ ] **Search and Filters**
-  - Filter events by title or date range via the API.
+  - [x] Filter events by title or date range via the API.
   - Provide search controls in the frontend.
 
 - [ ] **Improved Validation and Error Messages**

--- a/calendar-app/app/Http/Controllers/EventController.php
+++ b/calendar-app/app/Http/Controllers/EventController.php
@@ -9,9 +9,23 @@ use App\Http\Controllers\Controller;
 
 class EventController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        return Event::with('rsvps')->get();
+        $query = Event::query()->with('rsvps');
+
+        if ($title = $request->query('title')) {
+            $query->where('title', 'like', "%{$title}%");
+        }
+
+        if ($start = $request->query('start')) {
+            $query->where('start_time', '>=', $start);
+        }
+
+        if ($end = $request->query('end')) {
+            $query->where('end_time', '<=', $end);
+        }
+
+        return $query->get();
     }
 
     public function store(StoreEventRequest $request)

--- a/calendar-app/tests/Feature/EventFilterTest.php
+++ b/calendar-app/tests/Feature/EventFilterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function filter_events_by_title(): void
+    {
+        Event::factory()->create(['title' => 'Company Meeting']);
+        Event::factory()->create(['title' => 'Team Lunch']);
+
+        $response = $this->getJson('/api/events?title=Meeting');
+
+        $response->assertStatus(200)
+                 ->assertJsonFragment(['title' => 'Company Meeting'])
+                 ->assertJsonMissing(['title' => 'Team Lunch']);
+    }
+
+    /** @test */
+    public function filter_events_by_date_range(): void
+    {
+        Event::factory()->create([
+            'start_time' => '2024-01-10 10:00:00',
+            'end_time' => '2024-01-10 11:00:00',
+        ]);
+        Event::factory()->create([
+            'start_time' => '2024-02-10 10:00:00',
+            'end_time' => '2024-02-10 11:00:00',
+        ]);
+
+        $response = $this->getJson('/api/events?start=2024-01-01&end=2024-01-31');
+
+        $response->assertStatus(200)
+                 ->assertJsonCount(1);
+    }
+}


### PR DESCRIPTION
## Summary
- allow filtering events by title and date range
- document new filtering query parameters
- track progress in TASKS
- test event filtering

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68487644aaa4832ebd696d65b5ee4da1